### PR TITLE
Move react dependencies to peerDependency + loosen requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # dependencies
 node_modules
+package-lock.json
 
 # compiled files
 lib/

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "clean": "rm -r lib",
     "prepublish": "npm run compile"
   },
-  "dependencies": {
-    "react": "^15.4.2",
-    "react-bootstrap": "^0.30.8",
-    "react-dom": "^15.4.2"
+  "peerDependency": {
+    "react": ">= 15.4.2 < 17.0.0",
+    "react-bootstrap": ">= 0.30.8 < 0.33.0",
+    "react-dom": ">= 15.4.2 < 17.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.0",


### PR DESCRIPTION
This moves the dependencies to peerDependency so they don't bundle their own react version but rather use the same as the top project. See https://nodejs.org/en/blog/npm/peer-dependencies/ as well.

It also loosens the requirements to allow for the current versions.